### PR TITLE
Fix for a security vulnerability "Path Traversal" (CWE-35)

### DIFF
--- a/bash-server.sh
+++ b/bash-server.sh
@@ -193,7 +193,7 @@ parseAndPrint(){
     parseCookieData
 
 
-    if [[ -z "${COOKIE["$SESSION_COOKIE"]}" ]]; then
+    if [[ -z "${COOKIE["$SESSION_COOKIE"]}" ]] || [[ "${COOKIE["$SESSION_COOKIE"]}" == *..* ]]; then
         SESSION_ID="$(uuidgen)"
     else
         SESSION_ID="${COOKIE["$SESSION_COOKIE"]}"
@@ -276,7 +276,7 @@ serveHtml(){
         DOCUMENT_ROOT="${DOCUMENT_ROOT%/}"
 
         # Don't allow going out of DOCUMENT_ROOT
-        case "$DOCUMENT_ROOT" in
+        case "$REQUEST_PATH" in
             *".."*|*"~"*)
                 httpSendStatus 404
                 printf '404 Page Not Found!\n'


### PR DESCRIPTION
I have found a security vulnerability related to path traversal (CWE-35) and have fixed it.

**REQUEST_PATH part**
> bash-5.2# nc 127.0.0.1 8080
> GET **/../../../../../../etc/passwd** HTTP/1.0
> 
> HTTP/1.0 200 OK
> Content-Length: 1172
> 
> **root:x:0:0:root:/root:/bin/ash**
> bin:x:1:1:bin:/bin:/sbin/nologin
> daemon:x:2:2:daemon:/sbin:/sbin/nologin
> ...

**SESSION_ID part**
> bash-5.2# nc 127.0.0.1 8080
> GET / HTTP/1.0
> Cookie: BASHSESSID=**../../../../../etc/passwd**
> 
> :     (main) -  Listening on 127.0.0.1 port 8080
> ::    (cookieSet <- runner <- buildResponse <- parseAndPrint <- main) -  trii=lek; Max-Age=5000
> **/tmp/../../../../../etc/passwd: line 1: root:x:0:0:root:/root:/bin/ash: No such file or directory**
> /tmp/../../../../../etc/passwd: line 2: bin:x:1:1:bin:/bin:/sbin/nologin: No such file or directory
> /tmp/../../../../../etc/passwd: line 3: daemon:x:2:2:daemon:/sbin:/sbin/nologin: No such file or directory
> ...

